### PR TITLE
WIP: Resolve "Fix or remove following mksh versions" (#39)

### DIFF
--- a/plugins/shell-build/bin/shell-build
+++ b/plugins/shell-build/bin/shell-build
@@ -1486,6 +1486,22 @@ use_freebsd_pkg() {
   fi
 }
 
+has_broken_gcc_bug_55009() {
+  local gcc_version
+  gcc_version="$(gcc --version | head -n1)"
+  gcc_version="${gcc_version##* }"
+  case "${gcc_version}" in
+    1*|2*|3*) return 1 ;;
+    4*)
+      case "${gcc_version:2}" in
+        1*|2*|3*|4*|5*|6*|7*) return 1 ;;
+        *) return 0 ;;
+      esac
+    ;;
+    *) return 0 ;;
+  esac
+}
+
 has_broken_mac_readline() {
   # Mac OS X 10.4 has broken readline.
   # https://github.com/shenv/shenv/issues/23

--- a/plugins/shell-build/share/shell-build/mksh-R40d
+++ b/plugins/shell-build/share/shell-build/mksh-R40d
@@ -1,1 +1,4 @@
+# require libmpc-dev, gcc-multilib
+# install_package "gcc-4.7.4" "https://ftpmirror.gnu.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.gz" standard --if has_broken_gcc_bug_55009
+
 install_nightly_package "mksh-R40d" "https://www.mirbsd.org/MirOS/dist/mir/mksh/mksh-R40d.cpio.gz#2df19532a2c4c1cf99dfce4c8b1bca8df65f027c5da1f5d2f561df53567c1057" mksh build_script bin_install


### PR DESCRIPTION
Work In Progress, do not merge.

For now, `gcc-4.7` seems to complicated to install and use to build problematic mksh versions (see #39).
It's heavy, takes a long time to make (or would need tweaking to build only some targets), and has dependencies to `libmpc-dev` and `gcc-multilib` to compile. It also seems to be complicated to install with `apt-get` (not even available on Debian 8 Jessie, can't `dpkg -i` it from https://packages.debian.org/wheezy/amd64/gcc-4.7-base/download as it breaks other versions, etc.), so the issue will not be fixed for now.