### PR TITLE
WIP: fix(exec): don't add system bin dir to $PATH

### DIFF
--- a/libexec/shenv-exec
+++ b/libexec/shenv-exec
@@ -41,7 +41,7 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-# Cshell's `sys.executable` requires the `SHENV_BIN_PATH` to be at the top of the `PATH`.
-# https://github.com/shenv/shenv/issues/98
-export PATH="${SHENV_BIN_PATH}:${PATH}"
+if [ "$SHENV_VERSION" != "system" ]; then
+  export PATH="${SHENV_BIN_PATH}:${PATH}"
+fi
 exec -a "$SHENV_COMMAND" "$SHENV_COMMAND_PATH" "$@"

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -77,33 +77,3 @@ ${SHENV_ROOT}/versions/3.4/bin/shell
   args
 OUT
 }
-
-@test "supports shell -S <cmd>" {
-  export SHENV_VERSION="3.4"
-
-  # emulate `shell -S' behavior
-  create_executable "shell" <<SH
-#!$BASH
-if [[ \$1 == "-S"* ]]; then
-  found="\$(PATH="\${SHELLPATH:-\$PATH}" which \$2)"
-  # assert that the found executable has shell for shebang
-  if head -1 "\$found" | grep shell >/dev/null; then
-    \$BASH "\$found"
-  else
-    echo "shell: no shell script found in input (LoadError)" >&2
-    exit 1
-  fi
-else
-  echo 'shell 3.4 (shenv test)'
-fi
-SH
-
-  create_executable "fab" <<SH
-#!/usr/bin/env shell
-echo hello fab
-SH
-
-  shenv-rehash
-  run shell -S fab
-  assert_success "hello fab"
-}


### PR DESCRIPTION
This causes interoperability issues with other *envs such as pyenv,
because it uses the shell so that it goes through us, and if we stuff a
system bin dir to $PATH, we likely end up placing also system python
things in a location inconsistent with what pyenv is configured to do
and expects.

The code in question was apparently borrowed from pyenv, autoreplacing python references with shell ones, with results that don't make sense. Synced this bit with rbenv, because the pyenv specialties aren't needed here.

WIP: breaks some tests, not sure why. The "supports shell -S <cmd>" test was one of those -- removed because doesn't seem to make sense for shells in the first place, it's ruby stuff.