### PR TITLE
Remove install lines for old openssl and readline from zsh definitions

### DIFF
--- a/plugins/shell-build/share/shell-build/zsh-4.0.4
+++ b/plugins/shell-build/share/shell-build/zsh-4.0.4
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-4.0.4" "https://sourceforge.net/projects/zsh/files/zsh/4.0.4/zsh-4.0.4.tar.gz#2d95660e2047955d2fe8ba2afaa8b35b2b442c2f351637e7e2383327f6122430"

--- a/plugins/shell-build/share/shell-build/zsh-4.2.1
+++ b/plugins/shell-build/share/shell-build/zsh-4.2.1
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-4.2.1" "https://sourceforge.net/projects/zsh/files/zsh/4.2.1/zsh-4.2.1.tar.gz#6c53b0444c9928bcb88687edb15f46610c3ebea34ca2918e55c72aef4e7fdef8"

--- a/plugins/shell-build/share/shell-build/zsh-4.2.4
+++ b/plugins/shell-build/share/shell-build/zsh-4.2.4
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-4.2.4" "https://sourceforge.net/projects/zsh/files/zsh/4.2.4/zsh-4.2.4.tar.gz#cfb0f45c86de818dcd1d81bcba16680b38c1d61620e76663694d61c6b6ae94a3"

--- a/plugins/shell-build/share/shell-build/zsh-4.2.5
+++ b/plugins/shell-build/share/shell-build/zsh-4.2.5
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-4.2.5" "https://sourceforge.net/projects/zsh/files/zsh/4.2.5/zsh-4.2.5.tar.gz#bf3de16646e94e8bc1813922f0f4256404d189d2b063769d647ad55f8ff3c9f2"

--- a/plugins/shell-build/share/shell-build/zsh-4.2.7
+++ b/plugins/shell-build/share/shell-build/zsh-4.2.7
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-4.2.7" "https://sourceforge.net/projects/zsh/files/zsh/4.2.7/zsh-4.2.7.tar.gz#6454dd3b1d27f2725edc7dd309d92073658cc1592f35789e81922ca936a302d2"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.0
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.0
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.0" "https://sourceforge.net/projects/zsh/files/zsh/5.0.0/zsh-5.0.0.tar.gz#835194ea83abd812b5fdb1d2bfa6427c4c4e95e771c4a75e9006037af8efd264"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.1
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.1
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.1" "https://sourceforge.net/projects/zsh/files/zsh/5.0.1/zsh-5.0.1.tar.gz#7e16da3bff64189aad1027844ee920fec1532535dffbbc8852ed0023a8731071"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.2
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.2
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.2" "https://sourceforge.net/projects/zsh/files/zsh/5.0.2/zsh-5.0.2.tar.gz#adc0c7881532419797713b7c503bcc5674c88f93a191e26f700b42c11a1a816e"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.4
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.4
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.4" "https://sourceforge.net/projects/zsh/files/zsh/5.0.4/zsh-5.0.4.tar.gz#ed1ceefc1f5b95f69181df62caab9915cc0caa8f4674d6b79b397e8630b706e6"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.5
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.5
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.5" "https://sourceforge.net/projects/zsh/files/zsh/5.0.5/zsh-5.0.5.tar.gz#b35cf19e4a6ba39fd03c6372b8a8760a491cc2e2e4aba3d15023ff291c2894b4"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.6
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.6
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.6" "https://sourceforge.net/projects/zsh/files/zsh/5.0.6/zsh-5.0.6.tar.gz#f03a3114a6b8d70402a92e885fd5d3a410cfecd2a7d1235fb74577b327153e39"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.7
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.7
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.7" "https://sourceforge.net/projects/zsh/files/zsh/5.0.7/zsh-5.0.7.tar.gz#43f0a4c179ef79bb8c9153575685f7f45f28a3615c8cf96345f503d5b9e7b919"

--- a/plugins/shell-build/share/shell-build/zsh-5.0.8
+++ b/plugins/shell-build/share/shell-build/zsh-5.0.8
@@ -1,3 +1,1 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "zsh-5.0.8" "https://sourceforge.net/projects/zsh/files/zsh/5.0.8/zsh-5.0.8.tar.gz#f57271ecf503df403db515916626de5d658d9f9e2c3b6d4da650544251ec080b"

--- a/plugins/shell-build/share/shell-build/zsh-5.1
+++ b/plugins/shell-build/share/shell-build/zsh-5.1
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.1" "https://sourceforge.net/projects/zsh/files/zsh/5.1/zsh-5.1.tar.xz#c3a654fa0ef26cb1a3228c9257101870e72899fde1cd815388b1b2cbbdfa59b4"
 else

--- a/plugins/shell-build/share/shell-build/zsh-5.1.1
+++ b/plugins/shell-build/share/shell-build/zsh-5.1.1
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.1.1" "https://sourceforge.net/projects/zsh/files/zsh/5.1.1/zsh-5.1.1.tar.xz#74e9453b5470b3c0970f9f93cfd603d241c3d7b1968adc0e4b3951073e8d3dec"
 else

--- a/plugins/shell-build/share/shell-build/zsh-5.2
+++ b/plugins/shell-build/share/shell-build/zsh-5.2
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.2" "https://sourceforge.net/projects/zsh/files/zsh/5.2/zsh-5.2.tar.xz#f17916320ffaa844bbd7ce48ceeb5945fc5f3eff64b149b4229bbfbdf3795a9d"
 else

--- a/plugins/shell-build/share/shell-build/zsh-5.3
+++ b/plugins/shell-build/share/shell-build/zsh-5.3
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.3" "https://sourceforge.net/projects/zsh/files/zsh/5.3/zsh-5.3.tar.xz#76f82cfd5ce373cf799a03b6f395283f128430db49202e3e3f512fb5a19d6f8a"
 else

--- a/plugins/shell-build/share/shell-build/zsh-5.3.1
+++ b/plugins/shell-build/share/shell-build/zsh-5.3.1
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.3.1" "https://sourceforge.net/projects/zsh/files/zsh/5.3.1/zsh-5.3.1.tar.xz#fc886cb2ade032d006da8322c09a7e92b2309177811428b121192d44832920da"
 else

--- a/plugins/shell-build/share/shell-build/zsh-5.4.1
+++ b/plugins/shell-build/share/shell-build/zsh-5.4.1
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.4.1" "https://sourceforge.net/projects/zsh/files/zsh/5.4.1/zsh-5.4.1.tar.xz#94cbd57508287e8faa081424509738d496f5f41e32ed890e3a5498ce05d3633b"
 else

--- a/plugins/shell-build/share/shell-build/zsh-5.4.2
+++ b/plugins/shell-build/share/shell-build/zsh-5.4.2
@@ -1,5 +1,3 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "zsh-5.4.2" "https://sourceforge.net/projects/zsh/files/zsh/5.4.2/zsh-5.4.2.tar.xz#a80b187b6b770f092ea1f53e89021d06c03d8bbe6a5e996bcca3267de14c5e52"
 else


### PR DESCRIPTION
I was adding new definitions, and I thought, surely these old openssl and readline versions should not be used for more recent zsh definitions? Then, maybe already existing zsh definitions should be updated too? But, that's not maintainable? Can we just get rid of these installation lines?